### PR TITLE
Webkit Audio Fix

### DIFF
--- a/script.js
+++ b/script.js
@@ -18,7 +18,7 @@ function audioContextBeep(index) {
   v.stop(a.currentTime + 0.01);
 }
 
-const beep = (AudioContext) ? audioContextBeep : beepFallback;
+const beep = AudioContext ? audioContextBeep : beepFallback;
 
 function clearDisplay() {
   const c = SORTVIEW.getContext('2d');

--- a/script.js
+++ b/script.js
@@ -1,7 +1,8 @@
+const AudioContext = window.AudioContext || window.webkitAudioContext
 const ARRAY = [];
 const SORTVIEW = document.querySelector('#sortView');
 
-function beepFallback() {}
+function beepFallback() { }
 
 function audioContextBeep(index) {
   if (document.querySelector('#disableSound').style.display === 'none') return;


### PR DESCRIPTION
Regarding your issue (#2), I have added a fix so that the webpage no longer crashes on Webkit browsers.

The issue appeared to be that webkit uses a prefixed version of AudioContext, and therefore AudioContext does not exist. Instead, a constant should be used, which uses either `window.AudioContext` or `window.webkitAudioContext`.

I've tested this on MacOS Big Sur and iOS 14 (Safari 14.0 on both), along with Google Chrome to check that any original functionality works.